### PR TITLE
Fix workflow attempting to double-move issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         column_name: 'Inbox'      
       
     - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      if: github.event.action == 'labeled'
       with:
         action-token: "${{ secrets.SIMON_ORG_TOKEN }}"
         project-url: "https://github.com/orgs/WootingKb/projects/2"
@@ -28,6 +29,7 @@ jobs:
         columns-to-ignore: "Freezer,Assigned,Done"
     
     - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      if: github.event.action == 'labeled'
       with:
         action-token: "${{ secrets.SIMON_ORG_TOKEN }}"
         project-url: "https://github.com/orgs/WootingKb/projects/2"
@@ -36,6 +38,7 @@ jobs:
         columns-to-ignore: "Freezer,Assigned,Done"
         
     - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      if: github.event.action == 'labeled'
       with:
         action-token: "${{ secrets.SIMON_ORG_TOKEN }}"
         project-url: "https://github.com/orgs/WootingKb/projects/2"


### PR DESCRIPTION
For every new issue, two events happen:
1. opened
2. labeled (due to the templates)

Because this "main.yml" handles both events, it is run twice, causing the second run to have an error.

Ideally, I would've split this workflow into 2 separate yml files, but in the interest of diffability, I just added an `if` to the offending steps.